### PR TITLE
Add blocklist feature to container image

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,15 +9,16 @@ This is the [hickory-dns](https://github.com/hickory-dns/hickory-dns#readme) Doc
 
 ## Enabled [features](https://github.com/hickory-dns/hickory-dns/#using-as-a-dependency-and-custom-features) in the image
 
-- `h3-ring`
-- `quic-ring`
-- `https-ring`
-- `dnssec-ring`
 - `ascii-art`
+- `blocklist`
+- `dnssec-ring`
+- `h3-ring`
+- `https-ring`
+- `quic-ring`
 - `resolver`
 - `recursor`
-- `sqlite`
 - `rustls-platform-verifier`
+- `sqlite`
 - `webpki-roots`
 
 ## Additional files

--- a/alpine/Dockerfile
+++ b/alpine/Dockerfile
@@ -13,7 +13,7 @@ ARG SOURCE_SHA256
 
 # https://docs.rs/crate/hickory-dns/0.25.1/features
 ARG DEFAULT_FEATURES="ascii-art,resolver,sqlite"
-ARG FEATURES="h3-ring,quic-ring,https-ring,dnssec-ring,recursor,rustls-platform-verifier,webpki-roots,$DEFAULT_FEATURES"
+ARG FEATURES="h3-ring,quic-ring,https-ring,dnssec-ring,recursor,rustls-platform-verifier,webpki-roots,blocklist,$DEFAULT_FEATURES"
 
 WORKDIR /workspace
 RUN \


### PR DESCRIPTION
Trying to add the blocklist feature to the build of hickory-dns going to the container exposed on the registry.